### PR TITLE
Initialise main component

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const App = () => {
+    return (
+        <div>
+            <h1>Productivity App</h1>
+        </div>
+    )
+}
+
+export default App;

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8" />
+        <title>Productivity App</title>
+    </head>
+    <body>
+        <div id="app"></div>
+    </body>
+</html>

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { render } from 'react-dom';
+
+import App from './app';
+
+render(<App />, document.getElementById('app'));


### PR DESCRIPTION
# Description

Add initial main app component which will hold all other React components.

This will load a simple `<h1>` header saying 'Productivity App', but in the future, it will hold all the other components we will be using. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update