### PR TITLE
Reduce repetition in SASS styling

### DIFF
--- a/src/component/add-task-form.jsx
+++ b/src/component/add-task-form.jsx
@@ -13,7 +13,7 @@ const TaskForm = (props) => {
     }
 
     return (
-        <div id="add-task-form">
+        <div className="add-task-form" style={{ gridColumn: props.columnPos, gridRow: props.rowPos }} >
             <h2>Add task:</h2>
             <p>Enter a task you want to record below, then click the button to add it to the list.</p>
             <input type="text" name="task-name" value={taskName} onChange={(e) => setTaskName(e.target.value)} />

--- a/src/component/app.jsx
+++ b/src/component/app.jsx
@@ -17,7 +17,7 @@ const App = () => {
     return (
         <div id="container">
             <h1>Productivity App</h1>
-            <TaskForm addItem={addTaskToList} />
+            <TaskForm addItem={addTaskToList} columnPos={2} rowPos={2} />
             <List tasks={taskList} deleteItem={deleteTaskFromList} />
         </div>
     )

--- a/src/component/app.jsx
+++ b/src/component/app.jsx
@@ -18,7 +18,7 @@ const App = () => {
         <div id="container">
             <h1>Productivity App</h1>
             <TaskForm addItem={addTaskToList} columnPos={2} rowPos={2} />
-            <List tasks={taskList} deleteItem={deleteTaskFromList} />
+            <List tasks={taskList} deleteItem={deleteTaskFromList} columnPos={2} rowPos={3} />
         </div>
     )
 }

--- a/src/component/list.jsx
+++ b/src/component/list.jsx
@@ -12,7 +12,7 @@ const List = (props) => {
     });
 
     return (
-        <div id="taskList">
+        <div className="taskList" style={{ gridColumn: props.columnPos, gridRow: props.rowPos }}>
             <h2>Tasks to do:</h2>
             {
                 props.tasks.length > 0 ?

--- a/src/style/add-task-form.scss
+++ b/src/style/add-task-form.scss
@@ -1,6 +1,4 @@
-#add-task-form {
-    grid-column: 2;
-    grid-row: 2;
+.add-task-form {
     padding-left: 20px;
     padding-bottom: 20px;
 }

--- a/src/style/add-task-form.scss
+++ b/src/style/add-task-form.scss
@@ -3,11 +3,7 @@
     grid-row: 2;
     padding-left: 20px;
     padding-bottom: 20px;
-
-    h2 {
-        font-family: 'Courier New', Courier, monospace;
-    }
-
+    
     p {
         font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
     }

--- a/src/style/add-task-form.scss
+++ b/src/style/add-task-form.scss
@@ -3,9 +3,4 @@
     grid-row: 2;
     padding-left: 20px;
     padding-bottom: 20px;
-    
-    p {
-        font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
-    }
-
 }

--- a/src/style/app.scss
+++ b/src/style/app.scss
@@ -19,3 +19,7 @@ h1 {
 h2 {
     font-family: 'Courier New', Courier, monospace;
 }
+
+p {
+    font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+}

--- a/src/style/app.scss
+++ b/src/style/app.scss
@@ -1,6 +1,7 @@
 $body-color: red;
 $font-size: 50px;
 $heading-font-family: 'Courier New', Courier, monospace;
+$paragraph-font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
 
 #container {
   display: grid;
@@ -12,18 +13,18 @@ h1 {
   grid-column: 1 / 4;
   grid-row: 1;
   text-align: center;
-  font-family: 'Courier New', Courier, monospace;
+  font-family: $heading-font-family;
   font-size: $font-size;
 }
 
 h2 {
-    font-family: 'Courier New', Courier, monospace;
+    font-family: $heading-font-family;
 }
 
 p {
-    font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+    font-family: $paragraph-font-family;
 }
 
 li {
-    font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+    font-family: $paragraph-font-family;
 }

--- a/src/style/app.scss
+++ b/src/style/app.scss
@@ -23,3 +23,7 @@ h2 {
 p {
     font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
 }
+
+li {
+    font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+}

--- a/src/style/app.scss
+++ b/src/style/app.scss
@@ -1,6 +1,6 @@
 $body-color: red;
 $font-size: 50px;
-
+$heading-font-family: 'Courier New', Courier, monospace;
 
 #container {
   display: grid;
@@ -14,4 +14,8 @@ h1 {
   text-align: center;
   font-family: 'Courier New', Courier, monospace;
   font-size: $font-size;
+}
+
+h2 {
+    font-family: 'Courier New', Courier, monospace;
 }

--- a/src/style/list.scss
+++ b/src/style/list.scss
@@ -8,8 +8,4 @@
     li {
         font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
     }
-
-    p {
-        font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
-    }
 }

--- a/src/style/list.scss
+++ b/src/style/list.scss
@@ -4,8 +4,4 @@
     background-color: #b0e0e6;
     border-radius: 10px;
     padding-left: 20px;
-
-    li {
-        font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
-    }
 }

--- a/src/style/list.scss
+++ b/src/style/list.scss
@@ -5,10 +5,6 @@
     border-radius: 10px;
     padding-left: 20px;
 
-    h2 {
-        font-family: 'Courier New', Courier, monospace;
-    }
-
     li {
         font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
     }

--- a/src/style/list.scss
+++ b/src/style/list.scss
@@ -1,6 +1,4 @@
-#taskList {
-    grid-column: 2;
-    grid-row: 3;
+.taskList {
     background-color: #b0e0e6;
     border-radius: 10px;
     padding-left: 20px;


### PR DESCRIPTION
# Description

Reduce the repetition in SASS styling by doing the following:
- [x] Moving the font-family property values into variables in the app SCSS file
- [x] Pass the grid properties to the components as props to avoid using the style
- [x] Change the IDs to classes to reflect the reusable nature of components

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update